### PR TITLE
Add support for searching system/user dirs for config and css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**/__pycache__
+**/data.pickle
+**/gtk-weechat.conf

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ cd gtk-weechat
 python3 gtk-weechat.py
 ```
 
+Configuration is stored in `$XDG_CONFIG_HOME/gtk-weechat/gtk-weechat.conf`, or the local source directory.
+
+Styles can be loaded from, in order of precedence, `XDG_DATA_HOME/gtk-weechat/css/`, `$XDG_DATA_DIRS/gtk-weechat/css/` or the local source directory
+
 ## Contributing
 Bug reports are greatly appreciated.
 

--- a/buffer.py
+++ b/buffer.py
@@ -23,7 +23,6 @@ import re
 import datetime
 from gi.repository import Gtk, Gdk, GObject, Pango
 import color
-import config as config_module
 
 URL_PATTERN = re.compile(
     r"http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
@@ -51,7 +50,7 @@ class ChatTextBuffer(Gtk.TextBuffer):
 
         # We need the color class that convert formatting codes in network
         # data to codes that the parser functions in this class can handle
-        self._color = color.Color(config_module.color_options(), False)
+        self._color = color.Color(config.color_options(), False)
 
         # Text tags used for formatting
         self.time_tag = self.create_tag(
@@ -77,7 +76,8 @@ class ChatTextBuffer(Gtk.TextBuffer):
         delta = d-self.d_previous
         if delta.total_seconds() >= 5*60 and message_type != MessageType.SERVER_MESSAGE and prefix != self.last_prefix:
             self.insert_with_tags(self.get_end_iter(), d.strftime(
-                self.config['look']['buffer_time_format']) + "\n", self.time_tag)
+                self.config.get('look', 'buffer_time_format')) + "\n",
+                self.time_tag)
             self.last_message_type = MessageType.TIME_STAMP
             self.d_previous = d
 
@@ -161,12 +161,12 @@ class ChatTextBuffer(Gtk.TextBuffer):
                 text, True if self.attr_tag["*"] in attr_list else False)
             indent_tag.props.indent = -width
             indent_tag.props.left_margin = self.longest_prefix - \
-                width+int(self.config['look']['margin_size'])
+                width+int(self.config.get('look', 'margin_size'))
             if self.last_message_type != MessageType.TIME_STAMP and (msg_type == MessageType.CHAT_MESSAGE or msg_type != self.last_message_type):
                 indent_tag.props.pixels_above_lines = 10
         elif indent == "no_prefix":
             indent_tag.props.left_margin = self.longest_prefix + \
-                int(self.config['look']['margin_size'])
+                int(self.config.get('look', 'margin_size'))
         if indent in ("no_prefix", "text"):
             stripped_items = ''.join(stripped_items)
             for url_match in URL_PATTERN.finditer(stripped_items):
@@ -236,7 +236,8 @@ class BufferWidget(Gtk.Box):
         self.textview.set_editable(False)
         self.textview.set_can_focus(False)
         self.textview.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
-        self.textview.set_right_margin(int(self.config['look']['margin_size']))
+        self.textview.set_right_margin(int(self.config.get('look',
+                                                           'margin_size')))
         self.scrolledwindow.add(self.textview)
         horizontal_box.pack_start(self.scrolledwindow, True, True, 0)
         self.adjustment = self.textview.get_vadjustment()

--- a/connection.py
+++ b/connection.py
@@ -19,19 +19,18 @@
 #
 
 from gi.repository import Gtk, GObject, Gdk
-import config
 
 
 class ConnectionSettings(Gtk.Window):
     """Window for entering connection details."""
     __gsignals__ = {"connect": (GObject.SIGNAL_RUN_FIRST, None, ())}
 
-    def __init__(self, settings):
+    def __init__(self, config):
         Gtk.Window.__init__(self, title="Connection")
         self.set_type_hint(Gdk.WindowTypeHint.DIALOG)
         self.set_modal(True)
         self.set_keep_above(True)
-        self.settings = settings
+        self.config = config
         self.connect("destroy", self._on_cancel)
         grid = Gtk.Grid()
         # Set up a headerbar
@@ -97,13 +96,14 @@ class ConnectionSettings(Gtk.Window):
         self.hide()
 
     def _save_settings(self):
-        self.settings["relay"]["server"] = self.entry1.get_text()
-        self.settings["relay"]["port"] = self.entry2.get_text()
-        self.settings["relay"]["password"] = self.entry3.get_text()
-        self.settings["relay"]["ssl"] = "on" if self.switch1.get_active() else "off"
-        self.settings["relay"]["autoconnect"] = "on" if self.switch2.get_active(
-        ) else "off"
-        config.write(self.settings)
+        self.config.set("relay", "server", self.entry1.get_text())
+        self.config.set("relay", "port", self.entry2.get_text())
+        self.config.set("relay", "password", self.entry3.get_text())
+        self.config.set("relay", "ssl",
+                        "on" if self.switch1.get_active() else "off")
+        self.config.set("relay", "autoconnect",
+                        "on" if self.switch2.get_active() else "off")
+        self.config.write()
         self.hide()
 
     def _on_connect(self, widget):
@@ -113,11 +113,11 @@ class ConnectionSettings(Gtk.Window):
         self.emit("connect")
 
     def _fill_in_settings(self):
-        self.entry1.set_text(self.settings["relay"]["server"])
-        self.entry2.set_text(self.settings["relay"]["port"])
-        self.entry3.set_text(self.settings["relay"]["password"])
+        self.entry1.set_text(self.config.get("relay", "server"))
+        self.entry2.set_text(self.config.get("relay", "port"))
+        self.entry3.set_text(self.config.get("relay", "password"))
 
         self.switch1.set_active(
-            self.settings["relay"]["ssl"] == "on")
+            self.config.set("relay", "ssl", "on"))
         self.switch2.set_active(
-            self.settings["relay"]["autoconnect"] == "on")
+            self.config.set("relay", "autoconnect", "on"))

--- a/gtk-weechat.py
+++ b/gtk-weechat.py
@@ -27,7 +27,7 @@ from gi.repository import Gtk, Gio, GLib, Gdk
 from state import State
 from connection import ConnectionSettings
 from bufferlist import BufferList
-import config
+from config import GTKWeechatConfig
 from buffer import Buffer
 import protocol
 from network import Network, ConnectionStatus
@@ -157,7 +157,7 @@ class MainWindow(Gtk.ApplicationWindow):
 
         # Autoconnect if necessary
         if self.net.check_settings() is True and \
-                            self.config["relay"]["autoconnect"] == "on":
+                self.config.get("relay", "autoconnect") == "on":
             if self.net.connect_weechat() is False:
                 print("Failed to connect.")
             else:
@@ -585,10 +585,10 @@ class Application(Gtk.Application):
 
 
 # Start the application
-CONFIG = config.read()
-CONNECTION_SETTINGS = ConnectionSettings(CONFIG)
+config = GTKWeechatConfig(CONFIG_FILENAME)
+CONNECTION_SETTINGS = ConnectionSettings(config)
 STATE = State("data.pickle")
 STATE.load_from_file()
-APP = Application(CONFIG)
+APP = Application(config)
 APP.run()
 STATE.dump_to_file()

--- a/gtk-weechat.py
+++ b/gtk-weechat.py
@@ -36,7 +36,23 @@ if sys.version_info < (3,):
         *sys.version_info))
 
 
-CONFIG_DIR = os.path.dirname(os.path.realpath(__file__))
+CONFIG_DIR = GLib.get_user_config_dir()
+if not CONFIG_DIR:
+    # fall back to using local directory
+    CONFIG_DIR = os.path.dirname(os.path.realpath(__file__))
+else:
+    CONFIG_DIR = os.path.join(CONFIG_DIR, 'gtk-weechat')
+    os.makedirs(CONFIG_DIR, mode=0o0755, exist_ok=True)
+CONFIG_FILENAME = '%s/gtk-weechat.conf' % CONFIG_DIR
+
+CSS_STYLE_DIR = os.path.dirname(os.path.realpath(__file__))
+for dir in GLib.get_system_data_dirs():
+    if os.path.exists(data_dir := os.path.join(dir, 'gtk-weechat', 'css')):
+        CSS_STYLE_DIR = data_dir
+# prefer styles in user data dir
+if os.path.exists(user_data_dir := os.path.join(GLib.get_user_data_dir(),
+                                                'gtk-weechat', 'css')):
+    CSS_STYLE_DIR = user_data_dir
 
 
 class MainWindow(Gtk.ApplicationWindow):
@@ -153,7 +169,7 @@ class MainWindow(Gtk.ApplicationWindow):
         # Enable darkmode if enabled before
         self.dark_fallback_provider = Gtk.CssProvider()
         self.dark_fallback_provider.load_from_path(
-            "{}/dark_fallback.css".format(CONFIG_DIR))
+            "{}/dark_fallback.css".format(CSS_STYLE_DIR))
         if STATE.get_dark():
             menuitem_darkmode.set_active(True)
 

--- a/network.py
+++ b/network.py
@@ -61,15 +61,15 @@ class Network(GObject.GObject):
 
     def check_settings(self):
         """ Returns True if settings required to connect are filled in. """
-        return self.config["relay"]["server"] != ""\
-            and self.config["relay"]["port"] != ""
+        return self.config.get("relay", "server") != ""\
+            and self.config.get("relay", "port") != ""
 
     def connect_weechat(self):
         """Sets up a socket connected to the WeeChat relay."""
         if not self.check_settings():
             return False
-        self.host = self.config["relay"]["server"]
-        port_str = self.config["relay"]["port"]
+        self.host = self.config.get("relay", "server")
+        port_str = self.config.get("relay", "port")
         try:
             self.port = int(port_str)
         except ValueError:
@@ -78,7 +78,7 @@ class Network(GObject.GObject):
         network_address = Gio.NetworkAddress.new(self.host, self.port)
         self.socket = None
         self.socketclient = Gio.SocketClient.new()
-        if self.config["relay"]["ssl"] == "on":
+        if self.config.get("relay", "ssl") == "on":
             self.socketclient.set_tls(True)
             self.socketclient.set_tls_validation_flags(Gio.TlsCertificateFlags.EXPIRED |
                                                        Gio.TlsCertificateFlags.REVOKED |
@@ -109,11 +109,11 @@ class Network(GObject.GObject):
             self.connection_status = ConnectionStatus.CONNECTED
             self.emit("connectionChanged")
             self.send_to_weechat(_PROTO_INIT_CMD.format(
-                password=self.config["relay"]["password"],
+                password=self.config.get("relay", "password"),
                 compression="on")
                 + "\n")
             self.send_to_weechat(_PROTO_SYNC_CMDS.format(
-                lines=self.config["relay"]["lines"])
+                lines=self.config.get("relay", "lines"))
                 + "\n")
             self.input = self.socket.get_input_stream()
             self.input.read_bytes_async(


### PR DESCRIPTION
This is a fairly large change that:

1) changes the application to use a new `GTKWeechatConfig` singleton for managing/accessing config

2) changes where the application searches for config and css files, preferring user and system-wide (only for css) directories, and falling back to the local directory

These changes will make it easier for folks to package this application for various Linux distros. I hope to package this for Alpine Linux at some point, to be used in postmarketOS for mobile devices.